### PR TITLE
A RPC implementation based on KCP-protocol supported

### DIFF
--- a/include/asio2/external/beast.hpp
+++ b/include/asio2/external/beast.hpp
@@ -36,7 +36,7 @@
 	#endif
 #else
 	#ifndef BOOST_BEAST_USE_STD_STRING_VIEW
-	#define BOOST_NO_CXX17_HDR_STRING_VIEW
+	#define BOOST_BEAST_USE_STD_STRING_VIEW
 	#endif
 	#include <boost/beast.hpp>
 	#if defined(ASIO2_ENABLE_SSL) || defined(ASIO2_USE_SSL)

--- a/include/asio2/external/beast.hpp
+++ b/include/asio2/external/beast.hpp
@@ -36,7 +36,7 @@
 	#endif
 #else
 	#ifndef BOOST_BEAST_USE_STD_STRING_VIEW
-	#define BOOST_BEAST_USE_STD_STRING_VIEW
+	#define BOOST_NO_CXX17_HDR_STRING_VIEW
 	#endif
 	#include <boost/beast.hpp>
 	#if defined(ASIO2_ENABLE_SSL) || defined(ASIO2_USE_SSL)

--- a/include/asio2/rpc/rpc_server.hpp
+++ b/include/asio2/rpc/rpc_server.hpp
@@ -21,6 +21,7 @@
 
 #include <asio2/config.hpp>
 
+#include <asio2/udp/udp_server.hpp>
 #include <asio2/tcp/tcp_server.hpp>
 #include <asio2/tcp/tcps_server.hpp>
 #include <asio2/http/ws_server.hpp>
@@ -31,6 +32,10 @@
 namespace asio2::detail
 {
 	ASIO2_CLASS_FORWARD_DECLARE_BASE;
+
+	ASIO2_CLASS_FORWARD_DECLARE_UDP_BASE;
+	ASIO2_CLASS_FORWARD_DECLARE_UDP_SERVER;
+
 	ASIO2_CLASS_FORWARD_DECLARE_TCP_BASE;
 	ASIO2_CLASS_FORWARD_DECLARE_TCP_SERVER;
 
@@ -42,6 +47,10 @@ namespace asio2::detail
 		friend executor_t;
 
 		ASIO2_CLASS_FRIEND_DECLARE_BASE;
+
+		ASIO2_CLASS_FRIEND_DECLARE_UDP_BASE;
+		ASIO2_CLASS_FRIEND_DECLARE_UDP_SERVER;
+
 		ASIO2_CLASS_FRIEND_DECLARE_TCP_BASE;
 		ASIO2_CLASS_FRIEND_DECLARE_TCP_SERVER;
 
@@ -91,6 +100,12 @@ namespace asio2::detail
 				return executor_t::template start(
 					std::forward<String>(host), std::forward<StrOrInt>(service),
 					std::forward<Args>(args)...);
+			}
+			else if constexpr (session_type::net_protocol == asio2::net_protocol::udp)
+			{
+				return executor_t::template start(
+					std::forward<String>(host), std::forward<StrOrInt>(service),
+					asio2::use_kcp, std::forward<Args>(args)...);
 			}
 			else
 			{
@@ -246,6 +261,15 @@ namespace asio2
 	class rpc_server_impl_t;
 
 	template<class derived_t, class session_t>
+	class rpc_server_impl_t<derived_t, session_t, asio2::net_protocol::udp>
+		: public detail::rpc_server_impl_t<derived_t, detail::udp_server_impl_t<derived_t, session_t>>
+	{
+	public:
+		using detail::rpc_server_impl_t<derived_t, detail::udp_server_impl_t<derived_t, session_t>>::
+			rpc_server_impl_t;
+	};
+
+	template<class derived_t, class session_t>
 	class rpc_server_impl_t<derived_t, session_t, asio2::net_protocol::tcp>
 		: public detail::rpc_server_impl_t<derived_t, detail::tcp_server_impl_t<derived_t, session_t>>
 	{
@@ -277,6 +301,7 @@ namespace asio2
 		using rpc_server_t<rpc_session_use<np>>::rpc_server_t;
 	};
 
+	using rpc_kcp_server = rpc_server_use<asio2::net_protocol::udp>;
 #if !defined(ASIO2_USE_WEBSOCKET_RPC)
 	/// Using tcp dgram mode as the underlying communication support
 	using rpc_server = rpc_server_use<asio2::net_protocol::tcp>;

--- a/include/asio2/rpc/rpc_session.hpp
+++ b/include/asio2/rpc/rpc_session.hpp
@@ -21,6 +21,7 @@
 
 #include <asio2/config.hpp>
 
+#include <asio2/udp/udp_session.hpp>
 #include <asio2/tcp/tcp_session.hpp>
 #include <asio2/tcp/tcps_session.hpp>
 #include <asio2/http/ws_session.hpp>
@@ -35,6 +36,11 @@
 namespace asio2::detail
 {
 	ASIO2_CLASS_FORWARD_DECLARE_BASE;
+	
+	ASIO2_CLASS_FORWARD_DECLARE_UDP_BASE;
+	ASIO2_CLASS_FORWARD_DECLARE_UDP_SERVER;
+	ASIO2_CLASS_FORWARD_DECLARE_UDP_SESSION;
+	
 	ASIO2_CLASS_FORWARD_DECLARE_TCP_BASE;
 	ASIO2_CLASS_FORWARD_DECLARE_TCP_SERVER;
 	ASIO2_CLASS_FORWARD_DECLARE_TCP_SESSION;
@@ -50,6 +56,11 @@ namespace asio2::detail
 		friend executor_t;
 
 		ASIO2_CLASS_FRIEND_DECLARE_BASE;
+		
+		ASIO2_CLASS_FRIEND_DECLARE_UDP_BASE;
+		ASIO2_CLASS_FRIEND_DECLARE_UDP_SERVER;
+		ASIO2_CLASS_FRIEND_DECLARE_UDP_SESSION;
+
 		ASIO2_CLASS_FRIEND_DECLARE_TCP_BASE;
 		ASIO2_CLASS_FRIEND_DECLARE_TCP_SERVER;
 		ASIO2_CLASS_FRIEND_DECLARE_TCP_SESSION;
@@ -143,6 +154,16 @@ namespace asio2
 		template<asio2::net_protocol np> struct template_args_rpc_session;
 
 		template<>
+		struct template_args_rpc_session<asio2::net_protocol::udp> : public template_args_udp_session
+		{
+			static constexpr asio2::net_protocol net_protocol = asio2::net_protocol::udp;
+
+			static constexpr bool rdc_call_cp_enabled = false;
+
+			static constexpr std::size_t function_storage_size = 72;
+		};
+
+		template<>
 		struct template_args_rpc_session<asio2::net_protocol::tcp> : public template_args_tcp_session
 		{
 			static constexpr asio2::net_protocol net_protocol = asio2::net_protocol::tcp;
@@ -163,7 +184,7 @@ namespace asio2
 		};
 	}
 
-
+	using rpc_session_args_udp = detail::template_args_rpc_session<asio2::net_protocol::udp>;
 	using rpc_session_args_tcp = detail::template_args_rpc_session<asio2::net_protocol::tcp>;
 	using rpc_session_args_ws  = detail::template_args_rpc_session<asio2::net_protocol::ws >;
 
@@ -172,6 +193,15 @@ namespace asio2
 
 
 	template<class derived_t, asio2::net_protocol np> class rpc_session_t;
+
+	template<class derived_t>
+	class rpc_session_t<derived_t, asio2::net_protocol::udp> : public detail::rpc_session_impl_t<derived_t,
+		detail::udp_session_impl_t<derived_t, detail::template_args_rpc_session<asio2::net_protocol::udp>>>
+	{
+	public:
+		using detail::rpc_session_impl_t<derived_t, detail::udp_session_impl_t<
+			derived_t, detail::template_args_rpc_session<asio2::net_protocol::udp>>>::rpc_session_impl_t;
+	};
 
 	template<class derived_t>
 	class rpc_session_t<derived_t, asio2::net_protocol::tcp> : public detail::rpc_session_impl_t<derived_t,
@@ -198,6 +228,7 @@ namespace asio2
 		using rpc_session_t<rpc_session_use<np>, np>::rpc_session_t;
 	};
 
+	using rpc_kcp_session = rpc_session_use<asio2::net_protocol::udp>;
 #if !defined(ASIO2_USE_WEBSOCKET_RPC)
 	/// Using tcp dgram mode as the underlying communication support
 	using rpc_session = rpc_session_use<asio2::net_protocol::tcp>;

--- a/test/bench/kcp/CMakeLists.txt
+++ b/test/bench/kcp/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# COPYRIGHT (C) 2017-2019, zhllxt
+# COPYRIGHT (C) 2017-2021, zhllxt
 # 
 # author   : zhllxt
 # email    : 37792738@qq.com
@@ -8,8 +8,8 @@
 # (See accompanying file LICENSE or see <http://www.gnu.org/licenses/>)
 #
 
-add_subdirectory (kcp)
-add_subdirectory (rpc)
-add_subdirectory (tcp)
-add_subdirectory (udp)
-add_subdirectory (rdc)
+add_subdirectory (asio2_kcp_rpc_qps_client)
+add_subdirectory (asio2_kcp_rpc_qps_server)
+
+add_subdirectory (asio2_kcp_tps_client)
+add_subdirectory (asio2_kcp_tps_server)

--- a/test/bench/kcp/asio2_kcp_rpc_qps_client/CMakeLists.txt
+++ b/test/bench/kcp/asio2_kcp_rpc_qps_client/CMakeLists.txt
@@ -1,0 +1,33 @@
+#
+# COPYRIGHT (C) 2017-2021, zhllxt
+# 
+# author   : zhllxt
+# email    : 37792738@qq.com
+# 
+# Distributed under the GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007
+# (See accompanying file LICENSE or see <http://www.gnu.org/licenses/>)
+#
+
+GroupSources (include/asio2 "/")
+#GroupSources (3rd/asio "/")
+
+aux_source_directory(. SRC_FILES)
+
+source_group("" FILES ${SRC_FILES})
+
+set(TARGET_NAME asio2_kcp_rpc_qps_client)
+
+add_executable (
+    ${TARGET_NAME}
+    ${ASIO2_FILES}
+    ${TARGET_NAME}.cpp
+)
+
+set_property(TARGET ${TARGET_NAME} PROPERTY FOLDER "bench/kcp")
+
+#SET_TARGET_PROPERTIES(${TARGET_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${ASIO2_EXES_DIR})
+
+set_target_properties(${TARGET_NAME} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY ${ASIO2_EXES_DIR})
+
+target_link_libraries(${TARGET_NAME} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(${TARGET_NAME} ${GENERAL_LIBS})

--- a/test/bench/kcp/asio2_kcp_rpc_qps_client/asio2_kcp_rpc_qps_client.cpp
+++ b/test/bench/kcp/asio2_kcp_rpc_qps_client/asio2_kcp_rpc_qps_client.cpp
@@ -1,0 +1,45 @@
+#include <asio2/rpc/rpc_client.hpp>
+
+std::string strmsg(128, 'A');
+
+std::function<void()> sender;
+
+int main()
+{
+	asio2::rpc_kcp_client client;
+
+	sender = [&]()
+	{
+		client.async_call([](std::string)
+		{
+			if (!asio2::get_last_error())
+				sender();
+		}, "echo", strmsg);
+	};
+
+	client.bind_init([&]() {
+		client.socket().set_option(
+			asio::ip::multicast::enable_loopback()
+		);
+		client.socket().set_option(
+			asio::ip::multicast::join_group(asio::ip::make_address("239.255.0.1"))
+		);
+	})
+	.bind_connect([&]()
+	{
+		if (!asio2::get_last_error())
+			sender();
+	});
+
+	client.start("127.0.0.1", "8080");
+
+	// -- sync qps test
+	//while (true)
+	//{
+	//	client.call<std::string>("echo", strmsg);
+	//}
+
+	while (std::getchar() != '\n');
+
+	return 0;
+}

--- a/test/bench/kcp/asio2_kcp_rpc_qps_server/CMakeLists.txt
+++ b/test/bench/kcp/asio2_kcp_rpc_qps_server/CMakeLists.txt
@@ -1,0 +1,33 @@
+#
+# COPYRIGHT (C) 2017-2021, zhllxt
+# 
+# author   : zhllxt
+# email    : 37792738@qq.com
+# 
+# Distributed under the GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007
+# (See accompanying file LICENSE or see <http://www.gnu.org/licenses/>)
+#
+
+GroupSources (include/asio2 "/")
+#GroupSources (3rd/asio "/")
+
+aux_source_directory(. SRC_FILES)
+
+source_group("" FILES ${SRC_FILES})
+
+set(TARGET_NAME asio2_kcp_rpc_qps_server)
+
+add_executable (
+    ${TARGET_NAME}
+    ${ASIO2_FILES}
+    ${TARGET_NAME}.cpp
+)
+
+set_property(TARGET ${TARGET_NAME} PROPERTY FOLDER "bench/kcp")
+
+#SET_TARGET_PROPERTIES(${TARGET_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${ASIO2_EXES_DIR})
+
+set_target_properties(${TARGET_NAME} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY ${ASIO2_EXES_DIR})
+
+target_link_libraries(${TARGET_NAME} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(${TARGET_NAME} ${GENERAL_LIBS})

--- a/test/bench/kcp/asio2_kcp_rpc_qps_server/asio2_kcp_rpc_qps_server.cpp
+++ b/test/bench/kcp/asio2_kcp_rpc_qps_server/asio2_kcp_rpc_qps_server.cpp
@@ -1,0 +1,47 @@
+#include <asio2/rpc/rpc_server.hpp>
+
+decltype(std::chrono::steady_clock::now()) time1 = std::chrono::steady_clock::now();
+decltype(std::chrono::steady_clock::now()) time2 = std::chrono::steady_clock::now();
+std::size_t qps = 0;
+bool _first = true;
+std::string echo(std::string a)
+{
+	if (_first)
+	{
+		_first = false;
+		time1 = std::chrono::steady_clock::now();
+		time2 = std::chrono::steady_clock::now();
+	}
+
+	qps++;
+	decltype(std::chrono::steady_clock::now()) time3 = std::chrono::steady_clock::now();
+	auto ms = std::chrono::duration_cast<std::chrono::seconds>(time3 - time2).count();
+	if (ms > 1)
+	{
+		time2 = time3;
+		ms = std::chrono::duration_cast<std::chrono::seconds>(time3 - time1).count();
+		double speed = (double)qps / (double)ms;
+		printf("%.1lf\n", speed);
+	}
+	return a;
+}
+
+int main()
+{
+	asio2::rpc_kcp_server server;
+
+	server.bind("echo", echo);
+	server.bind_init([&]() {
+		server.acceptor().set_option(
+			asio::ip::multicast::enable_loopback()
+		);
+		server.acceptor().set_option(
+			asio::ip::multicast::join_group(asio::ip::make_address("239.255.0.1"))
+		);
+	});
+	server.start("0.0.0.0", "8080");
+
+	while (std::getchar() != '\n');
+
+	return 0;
+}

--- a/test/bench/kcp/asio2_kcp_tps_client/CMakeLists.txt
+++ b/test/bench/kcp/asio2_kcp_tps_client/CMakeLists.txt
@@ -1,0 +1,34 @@
+#
+# COPYRIGHT (C) 2017-2021, zhllxt
+# 
+# author   : zhllxt
+# email    : 37792738@qq.com
+# 
+# Distributed under the GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007
+# (See accompanying file LICENSE or see <http://www.gnu.org/licenses/>)
+#
+
+#GroupSources (include/asio2 "/")
+#GroupSources (3rd/asio "/")
+
+aux_source_directory(. SRC_FILES)
+
+source_group("" FILES ${SRC_FILES})
+
+set(TARGET_NAME asio2_kcp_tps_client)
+
+add_executable (
+    ${TARGET_NAME}
+    ${TARGET_NAME}.cpp
+)
+
+set_property(TARGET ${TARGET_NAME} PROPERTY FOLDER "bench/kcp")
+
+#SET_TARGET_PROPERTIES(${TARGET_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${ASIO2_EXES_DIR})
+
+set_target_properties(${TARGET_NAME} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY ${ASIO2_EXES_DIR})
+
+target_link_libraries(${TARGET_NAME} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(${TARGET_NAME} ${GENERAL_LIBS})
+
+include_directories (${ASIO2_ROOT_DIR}/asio)

--- a/test/bench/kcp/asio2_kcp_tps_client/asio2_kcp_tps_client.cpp
+++ b/test/bench/kcp/asio2_kcp_tps_client/asio2_kcp_tps_client.cpp
@@ -1,0 +1,25 @@
+#include <asio2/udp/udp_client.hpp>
+
+int main()
+{
+	asio2::udp_client client(1500, 1500);
+
+	client.bind_connect([&]()
+	{
+		std::string strmsg(1024, 'A');
+
+		if (!asio2::get_last_error())
+			client.async_send(std::move(strmsg));
+
+	}).bind_recv([&](std::string_view data)
+	{
+		client.async_send(asio::buffer(data)); // no allocate memory
+		//client.async_send(data); // allocate memory
+	});
+
+	client.start("127.0.0.1", "8116", asio2::use_kcp);
+
+	while (std::getchar() != '\n');
+
+	return 0;
+}

--- a/test/bench/kcp/asio2_kcp_tps_server/CMakeLists.txt
+++ b/test/bench/kcp/asio2_kcp_tps_server/CMakeLists.txt
@@ -1,0 +1,34 @@
+#
+# COPYRIGHT (C) 2017-2021, zhllxt
+# 
+# author   : zhllxt
+# email    : 37792738@qq.com
+# 
+# Distributed under the GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007
+# (See accompanying file LICENSE or see <http://www.gnu.org/licenses/>)
+#
+
+#GroupSources (include/asio2 "/")
+#GroupSources (3rd/asio "/")
+
+aux_source_directory(. SRC_FILES)
+
+source_group("" FILES ${SRC_FILES})
+
+set(TARGET_NAME asio2_kcp_tps_server)
+
+add_executable (
+    ${TARGET_NAME}
+    ${TARGET_NAME}.cpp
+)
+
+set_property(TARGET ${TARGET_NAME} PROPERTY FOLDER "bench/kcp")
+
+#SET_TARGET_PROPERTIES(${TARGET_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${ASIO2_EXES_DIR})
+
+set_target_properties(${TARGET_NAME} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY ${ASIO2_EXES_DIR})
+
+target_link_libraries(${TARGET_NAME} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(${TARGET_NAME} ${GENERAL_LIBS})
+
+include_directories (${ASIO2_ROOT_DIR}/asio)

--- a/test/bench/kcp/asio2_kcp_tps_server/asio2_kcp_tps_server.cpp
+++ b/test/bench/kcp/asio2_kcp_tps_server/asio2_kcp_tps_server.cpp
@@ -1,0 +1,42 @@
+#include <asio2/udp/udp_server.hpp>
+
+decltype(std::chrono::steady_clock::now()) time1 = std::chrono::steady_clock::now();
+decltype(std::chrono::steady_clock::now()) time2 = std::chrono::steady_clock::now();
+std::size_t recvd_bytes = 0;
+bool first = true;
+
+int main()
+{
+	asio2::udp_server server(1500, 1500);
+
+	server.bind_recv([&](std::shared_ptr<asio2::udp_session>& session_ptr, std::string_view data)
+	{
+		if (first)
+		{
+			first = false;
+			time1 = std::chrono::steady_clock::now();
+			time2 = std::chrono::steady_clock::now();
+		}
+
+		recvd_bytes += data.size();
+
+		decltype(std::chrono::steady_clock::now()) time3 = std::chrono::steady_clock::now();
+		auto ms = std::chrono::duration_cast<std::chrono::seconds>(time3 - time2).count();
+		if (ms > 1)
+		{
+			time2 = time3;
+			ms = std::chrono::duration_cast<std::chrono::seconds>(time3 - time1).count();
+			double speed = (double)recvd_bytes / (double)ms / double(1024) / double(1024);
+			printf("%.1lf MByte/Sec\n", speed);
+		}
+
+		session_ptr->async_send(asio::buffer(data)); // no allocate memory
+		//session_ptr->async_send(data); // allocate memory
+	});
+
+	server.start("0.0.0.0", "8116", asio2::use_kcp);
+
+	while (std::getchar() != '\n');
+
+	return 0;
+}

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -57,6 +57,7 @@ endfunction()
 
 AddExecutableTarget(mqtt)
 AddExecutableTarget(rpc)
+AddExecutableTarget(rpc_kcp)
 AddExecutableTarget(timer)
 AddExecutableTarget(timer_enable_error)
 AddExecutableTarget(http)

--- a/test/unit/rpc_kcp.cpp
+++ b/test/unit/rpc_kcp.cpp
@@ -1,0 +1,1908 @@
+#include "unit_test.hpp"
+
+#include <asio2/config.hpp>
+
+#undef ASIO2_USE_WEBSOCKET_RPC
+
+#include <asio2/rpc/rpc_server.hpp>
+#include <asio2/rpc/rpc_client.hpp>
+#include <asio2/external/json.hpp>
+
+struct userinfo
+{
+	std::string name;
+	int age;
+	std::map<int, std::string> purview;
+
+	// User defined object types require serialized the members like this:
+	template <class Archive>
+	void serialize(Archive & ar)
+	{
+		ar(name);
+		ar(age);
+		ar(purview);
+	}
+};
+
+namespace nlohmann
+{
+	void operator<<(asio2::rpc::oarchive& sr, const nlohmann::json& j)
+	{
+		sr << j.dump();
+	}
+
+	void operator>>(asio2::rpc::iarchive& dr, nlohmann::json& j)
+	{
+		std::string v;
+		dr >> v;
+		j = nlohmann::json::parse(v);
+	}
+}
+
+std::string echo(std::string s)
+{
+	return s;
+}
+
+int add(int a, int b)
+{
+	return a + b;
+}
+
+rpc::future<int> async_add(int a, int b)
+{
+	rpc::promise<int> promise;
+	rpc::future<int> f = promise.get_future();
+
+	std::thread([a, b, promise = std::move(promise)]() mutable
+	{
+		std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+		promise.set_value(a + b);
+	}).detach();
+
+	return f;
+}
+
+rpc::future<void> async_test(std::shared_ptr<asio2::rpc_kcp_session>& session_ptr, std::string a, std::string b)
+{
+	ASIO2_CHECK(session_ptr->io().running_in_this_thread());
+
+	rpc::promise<void> promise;
+	rpc::future<void> f = promise.get_future();
+
+	ASIO2_CHECK(a == "abc" && b == "def");
+
+	std::thread([a, b, promise]() mutable
+	{
+		asio2::ignore_unused(a, b);
+		promise.set_value();
+	}).detach();
+
+	return f;
+}
+
+nlohmann::json test_json(nlohmann::json j)
+{
+	std::string s = j.dump();
+
+	return nlohmann::json::parse(s);
+}
+
+class usercrud
+{
+public:
+	double mul(double a, double b)
+	{
+		return a * b;
+	}
+
+	// If you want to know which client called this function, set the first parameter
+	// to std::shared_ptr<asio2::rpc_kcp_session>& session_ptr
+	userinfo get_user(std::shared_ptr<asio2::rpc_kcp_session> session_ptr)
+	{
+		ASIO2_CHECK(session_ptr->io().running_in_this_thread());
+
+		userinfo u;
+		u.name = "lilei";
+		u.age = 32;
+		u.purview = { {1,"read"},{2,"write"} };
+		return u;
+	}
+
+	// If you want to know which client called this function, set the first parameter
+	// to std::shared_ptr<asio2::rpc_kcp_session>& session_ptr
+	void del_user(std::shared_ptr<asio2::rpc_kcp_session> session_ptr, const userinfo& u)
+	{
+		ASIO2_CHECK(session_ptr->io().running_in_this_thread());
+		ASIO2_CHECK(u.name == "hanmeimei");
+		ASIO2_CHECK(u.age == 33);
+		ASIO2_CHECK(u.purview.size() == 2);
+		for (auto&[k, v] : u.purview)
+		{
+			ASIO2_CHECK(k == 10 || k == 20);
+			if (k == 10) ASIO2_CHECK(v == "get");
+			if (k == 20) ASIO2_CHECK(v == "set");
+		}
+	}
+};
+
+void heartbeat(std::shared_ptr<asio2::rpc_kcp_session>& session_ptr)
+{
+	ASIO2_CHECK(session_ptr->io().running_in_this_thread());
+}
+
+// set the first parameter to client reference to know which client was called
+void client_fn_test(asio2::rpc_kcp_client& client, std::string str)
+{
+	ASIO2_CHECK(client.io().running_in_this_thread());
+	ASIO2_CHECK(str == "i love you");
+}
+
+class my_rpc_kcp_client_kcp : public asio2::rpc_client_use<asio2::net_protocol::udp>
+{
+public:
+	using rpc_client_use<asio2::net_protocol::udp>::rpc_client_use;
+
+	using super::send;
+	using super::async_send;
+};
+
+void rpc_test()
+{
+	ASIO2_TEST_BEGIN_LOOP(test_loop_times);
+
+	// test max buffer size
+	{
+		asio2::rpc_server server(512, 1024, 4);
+
+		std::atomic<int> server_accept_counter = 0;
+		server.bind_accept([&](auto & session_ptr)
+		{
+			session_ptr->no_delay(true);
+
+			server_accept_counter++;
+
+			ASIO2_CHECK(!asio2::get_last_error());
+			ASIO2_CHECK(server.get_listen_address() == "127.0.0.1");
+			ASIO2_CHECK(server.get_listen_port() == 18010);
+			ASIO2_CHECK(session_ptr->remote_address() == "127.0.0.1");
+			ASIO2_CHECK(session_ptr->local_address() == "127.0.0.1");
+			ASIO2_CHECK(session_ptr->local_port() == 18010);
+			ASIO2_CHECK(server.io().running_in_this_thread());
+			ASIO2_CHECK(server.iopool().get(0).running_in_this_thread());
+
+		});
+		std::atomic<int> server_connect_counter = 0;
+		server.bind_connect([&](auto & session_ptr)
+		{
+			server_connect_counter++;
+
+			ASIO2_CHECK(!asio2::get_last_error());
+			ASIO2_CHECK(session_ptr->remote_address() == "127.0.0.1");
+			ASIO2_CHECK(session_ptr->local_address() == "127.0.0.1");
+			ASIO2_CHECK(session_ptr->local_port() == 18010);
+			ASIO2_CHECK(server.io().running_in_this_thread());
+			ASIO2_CHECK(server.iopool().get(0).running_in_this_thread());
+			ASIO2_CHECK(session_ptr->is_keep_alive());
+			ASIO2_CHECK(session_ptr->is_no_delay());
+
+		});
+		std::atomic<int> server_disconnect_counter = 0;
+		server.bind_disconnect([&](auto & session_ptr)
+		{
+			server_disconnect_counter++;
+
+			ASIO2_CHECK(asio2::get_last_error());
+			ASIO2_CHECK(session_ptr->socket().is_open());
+			ASIO2_CHECK(server.io().running_in_this_thread());
+			ASIO2_CHECK(server.iopool().get(0).running_in_this_thread());
+		});
+		std::atomic<int> server_init_counter = 0;
+		server.bind_init([&]()
+		{
+			server_init_counter++;
+
+			ASIO2_CHECK(!asio2::get_last_error());
+			ASIO2_CHECK(server.io().running_in_this_thread());
+			ASIO2_CHECK(server.iopool().get(0).running_in_this_thread());
+
+			asio::socket_base::reuse_address option;
+			server.acceptor().get_option(option);
+			ASIO2_CHECK(option.value());
+		});
+		std::atomic<int> server_start_counter = 0;
+		server.bind_start([&]()
+		{
+			server_start_counter++;
+
+			ASIO2_CHECK(!asio2::get_last_error());
+			ASIO2_CHECK(server.get_listen_address() == "127.0.0.1");
+			ASIO2_CHECK(server.get_listen_port() == 18010);
+			ASIO2_CHECK(server.io().running_in_this_thread());
+			ASIO2_CHECK(server.iopool().get(0).running_in_this_thread());
+		});
+		std::atomic<int> server_stop_counter = 0;
+		server.bind_stop([&]()
+		{
+			server_stop_counter++;
+
+			ASIO2_CHECK(asio2::get_last_error());
+			ASIO2_CHECK(server.get_listen_address() == "127.0.0.1");
+			ASIO2_CHECK(server.get_listen_port() == 18010);
+			ASIO2_CHECK(server.io().running_in_this_thread());
+			ASIO2_CHECK(server.iopool().get(0).running_in_this_thread());
+		});
+
+		server.bind("echo", echo);
+
+		bool server_start_ret = server.start("127.0.0.1", 18010);
+
+		ASIO2_CHECK(server_start_ret);
+		ASIO2_CHECK(server.is_started());
+
+		ASIO2_CHECK_VALUE(server_init_counter      .load(), server_init_counter       == 1);
+		ASIO2_CHECK_VALUE(server_start_counter     .load(), server_start_counter      == 1);
+
+		std::vector<std::shared_ptr<asio2::rpc_kcp_client>> clients;
+		std::atomic<int> client_init_counter = 0;
+		std::atomic<int> client_connect_counter = 0;
+		std::atomic<int> client_disconnect_counter = 0;
+		std::atomic<int> client_start_failed_counter = 0;
+		for (int i = 0; i < test_client_count; i++)
+		{
+			auto iter = clients.emplace_back(std::make_shared<asio2::rpc_kcp_client>());
+
+			asio2::rpc_kcp_client& client = *iter;
+
+			// set default rpc call timeout
+			client.set_default_timeout(std::chrono::seconds(3));
+			ASIO2_CHECK(client.get_default_timeout() == std::chrono::seconds(3));
+			client.set_auto_reconnect(false);
+			ASIO2_CHECK(!client.is_auto_reconnect());
+
+			client.bind_init([&]()
+			{
+				client_init_counter++;
+
+				client.set_no_delay(true);
+				if (asio2::get_last_error()) {
+					std::cerr << " val: " << asio2::get_last_error_val() << std::endl << asio2::get_last_error_msg() << std::endl;
+				}
+				ASIO2_CHECK(client.io().running_in_this_thread());
+				ASIO2_CHECK(client.iopool().get(0).running_in_this_thread());
+				ASIO2_CHECK(!asio2::get_last_error());
+				ASIO2_CHECK(client.is_keep_alive());
+				ASIO2_CHECK(client.is_reuse_address());
+				ASIO2_CHECK(client.is_no_delay());
+			});
+			client.bind_connect([&]()
+			{
+				ASIO2_CHECK(client.io().running_in_this_thread());
+				ASIO2_CHECK(client.iopool().get(0).running_in_this_thread());
+				ASIO2_CHECK(!asio2::get_last_error());
+				ASIO2_CHECK(client.get_local_address() == "127.0.0.1");
+				ASIO2_CHECK(client.get_remote_address() == "127.0.0.1");
+				ASIO2_CHECK(client.get_remote_port() == 18010);
+
+				client_connect_counter++;
+
+			});
+			client.bind_disconnect([&]()
+			{
+				client_disconnect_counter++;
+
+				ASIO2_CHECK(asio2::get_last_error());
+				ASIO2_CHECK(client.io().running_in_this_thread());
+				ASIO2_CHECK(client.iopool().get(0).running_in_this_thread());
+			});
+			client.bind_recv([&]([[maybe_unused]] std::string_view data)
+			{
+				ASIO2_CHECK(!asio2::get_last_error());
+				ASIO2_CHECK(client.io().running_in_this_thread());
+				ASIO2_CHECK(client.iopool().get(0).running_in_this_thread());
+				ASIO2_CHECK(!data.empty());
+				ASIO2_CHECK(client.is_started());
+			});
+
+			bool client_start_ret = client.start("127.0.0.1", 18010);
+			if (!client_start_ret)
+				client_start_failed_counter++;
+			ASIO2_CHECK(client_start_ret);
+			ASIO2_CHECK(!asio2::get_last_error());
+		}
+
+		while (server.get_session_count() < std::size_t(test_client_count - client_start_failed_counter))
+		{
+			ASIO2_TEST_WAIT_CHECK();
+		}
+
+		auto session_count = server.get_session_count();
+		ASIO2_CHECK_VALUE(session_count, session_count == std::size_t(test_client_count));
+
+		ASIO2_CHECK_VALUE(server_accept_counter    .load(), server_accept_counter     == test_client_count);
+		ASIO2_CHECK_VALUE(server_connect_counter   .load(), server_connect_counter    == test_client_count);
+
+		while (client_connect_counter < test_client_count - client_start_failed_counter)
+		{
+			ASIO2_TEST_WAIT_CHECK();
+		}
+
+		ASIO2_CHECK_VALUE(client_init_counter      .load(), client_init_counter    == test_client_count);
+		ASIO2_CHECK_VALUE(client_connect_counter   .load(), client_connect_counter == test_client_count);
+
+		std::string msg;
+		msg.resize(1500);
+		for (int i = 0; i < test_client_count; i++)
+		{
+			auto& clt = clients[i];
+			clients[i]->async_call("echo", msg).response([&clt](std::string s)
+			{
+				ASIO2_CHECK(s.empty());
+				// when send data failed, the error is not rpc::error::operation_aborted,
+				ASIO2_CHECK(asio2::get_last_error() == rpc::error::operation_aborted);
+				if (asio2::get_last_error() != rpc::error::operation_aborted)
+				{
+					// close the socket, this will trigger the auto reconnect
+					clt->socket().close();
+				}
+			});
+		}
+
+		while (client_disconnect_counter < test_client_count - client_start_failed_counter)
+		{
+			ASIO2_TEST_WAIT_CHECK();
+		}
+
+		ASIO2_CHECK_VALUE(client_disconnect_counter.load(), client_disconnect_counter == test_client_count);
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			ASIO2_CHECK(!clients[i]->is_stopped());
+			ASIO2_CHECK(!clients[i]->is_started());
+		}
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			clients[i]->stop();
+			ASIO2_CHECK(clients[i]->is_stopped());
+			ASIO2_CHECK(!clients[i]->is_started());
+		}
+
+		ASIO2_CHECK_VALUE(client_disconnect_counter.load(), client_disconnect_counter == test_client_count);
+
+		// use this to ensure the ASIO2_CHECK(session_ptr->is_started());
+		while (server_disconnect_counter != test_client_count- client_start_failed_counter)
+		{
+			ASIO2_TEST_WAIT_CHECK();
+		}
+
+		server.stop();
+		ASIO2_CHECK(server.is_stopped());
+
+		ASIO2_CHECK_VALUE(server_disconnect_counter.load(), server_disconnect_counter == test_client_count);
+		ASIO2_CHECK_VALUE(server_stop_counter      .load(), server_stop_counter       == 1);
+
+		//-----------------------------------------------------------------------------------------
+
+		ASIO2_CHECK_VALUE(server.get_session_count(), server.get_session_count() == std::size_t(0));
+
+		server_init_counter = 0;
+		server_start_counter = 0;
+		server_disconnect_counter = 0;
+		server_stop_counter = 0;
+		server_accept_counter = 0;
+		server_connect_counter = 0;
+
+		server_start_ret = server.start("127.0.0.1", 18010);
+
+		ASIO2_CHECK(server_start_ret);
+		ASIO2_CHECK(server.is_started());
+
+		ASIO2_CHECK_VALUE(server_init_counter      .load(), server_init_counter       == 1);
+		ASIO2_CHECK_VALUE(server_start_counter     .load(), server_start_counter      == 1);
+
+		client_init_counter = 0;
+		client_connect_counter = 0;
+		client_disconnect_counter = 0;
+		client_start_failed_counter = 0;
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			bool client_start_ret = clients[i]->async_start("127.0.0.1", 18010);
+			ASIO2_CHECK(client_start_ret);
+			ASIO2_CHECK(asio2::get_last_error() == asio::error::in_progress);
+		}
+
+		while (server.get_session_count() < std::size_t(test_client_count - client_start_failed_counter))
+		{
+			ASIO2_TEST_WAIT_CHECK();
+		}
+
+		ASIO2_CHECK_VALUE(server.get_session_count(), server.get_session_count() == std::size_t(test_client_count));
+
+		ASIO2_CHECK_VALUE(server_accept_counter    .load(), server_accept_counter     == test_client_count);
+		ASIO2_CHECK_VALUE(server_connect_counter   .load(), server_connect_counter    == test_client_count);
+
+		while (client_connect_counter < test_client_count - client_start_failed_counter)
+		{
+			ASIO2_TEST_WAIT_CHECK();
+		}
+
+		ASIO2_CHECK_VALUE(client_init_counter      .load(), client_init_counter    == test_client_count);
+		ASIO2_CHECK_VALUE(client_connect_counter   .load(), client_connect_counter == test_client_count);
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			auto& clt = clients[i];
+			clients[i]->async_call("echo", msg).response([&clt](std::string s)
+			{
+				ASIO2_CHECK(s.empty());
+				// when send data failed, the error is not rpc::error::operation_aborted,
+				ASIO2_CHECK(asio2::get_last_error() == rpc::error::operation_aborted);
+				if (asio2::get_last_error() != rpc::error::operation_aborted)
+				{
+					// close the socket, this will trigger the auto reconnect
+					clt->socket().close();
+				}
+			});
+		}
+
+		while (client_disconnect_counter < test_client_count - client_start_failed_counter)
+		{
+			ASIO2_TEST_WAIT_CHECK();
+		}
+
+		ASIO2_CHECK_VALUE(client_disconnect_counter.load(), client_disconnect_counter == test_client_count);
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			ASIO2_CHECK(!clients[i]->is_stopped());
+			ASIO2_CHECK(!clients[i]->is_started());
+		}
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			clients[i]->stop();
+			ASIO2_CHECK(clients[i]->is_stopped());
+			ASIO2_CHECK(!clients[i]->is_started());
+		}
+
+		ASIO2_CHECK_VALUE(client_disconnect_counter.load(), client_disconnect_counter == test_client_count);
+
+		// use this to ensure the ASIO2_CHECK(session_ptr->is_started());
+		while (server_disconnect_counter != test_client_count - client_start_failed_counter)
+		{
+			ASIO2_TEST_WAIT_CHECK();
+		}
+
+		server.stop();
+		ASIO2_CHECK(server.is_stopped());
+
+		ASIO2_CHECK_VALUE(server_disconnect_counter.load(), server_disconnect_counter == test_client_count);
+		ASIO2_CHECK_VALUE(server_stop_counter      .load(), server_stop_counter       == 1);
+	}
+
+	// test illegal data
+	{
+		asio2::rpc_kcp_server server;
+
+		std::atomic<int> server_accept_counter = 0;
+		std::atomic<int> server_connect_counter = 0;
+		server.bind_connect([&](auto & session_ptr)
+		{
+			server_connect_counter++;
+
+			ASIO2_CHECK(!asio2::get_last_error());
+			ASIO2_CHECK(session_ptr->remote_address() == "127.0.0.1");
+			ASIO2_CHECK(session_ptr->local_address() == "127.0.0.1");
+			ASIO2_CHECK(session_ptr->local_port() == 18010);
+			ASIO2_CHECK(server.io().running_in_this_thread());
+			ASIO2_CHECK(server.iopool().get(0).running_in_this_thread());
+			ASIO2_CHECK(session_ptr->is_keep_alive());
+			ASIO2_CHECK(session_ptr->is_no_delay());
+
+		});
+		std::atomic<int> server_disconnect_counter = 0;
+		server.bind_disconnect([&](auto & session_ptr)
+		{
+			server_disconnect_counter++;
+
+			ASIO2_CHECK(asio2::get_last_error());
+			ASIO2_CHECK(session_ptr->socket().is_open());
+			ASIO2_CHECK(server.io().running_in_this_thread());
+			ASIO2_CHECK(server.iopool().get(0).running_in_this_thread());
+		});
+		std::atomic<int> server_init_counter = 0;
+		server.bind_init([&]()
+		{
+			server_init_counter++;
+
+			ASIO2_CHECK(!asio2::get_last_error());
+			ASIO2_CHECK(server.io().running_in_this_thread());
+			ASIO2_CHECK(server.iopool().get(0).running_in_this_thread());
+
+			asio::socket_base::reuse_address option;
+			server.acceptor().get_option(option);
+			ASIO2_CHECK(option.value());
+		});
+		std::atomic<int> server_start_counter = 0;
+		server.bind_start([&]()
+		{
+			server_start_counter++;
+
+			ASIO2_CHECK(!asio2::get_last_error());
+			ASIO2_CHECK(server.get_listen_address() == "127.0.0.1");
+			ASIO2_CHECK(server.get_listen_port() == 18010);
+			ASIO2_CHECK(server.io().running_in_this_thread());
+			ASIO2_CHECK(server.iopool().get(0).running_in_this_thread());
+		});
+		std::atomic<int> server_stop_counter = 0;
+		server.bind_stop([&]()
+		{
+			server_stop_counter++;
+
+			ASIO2_CHECK(asio2::get_last_error());
+			ASIO2_CHECK(server.get_listen_address() == "127.0.0.1");
+			ASIO2_CHECK(server.get_listen_port() == 18010);
+			ASIO2_CHECK(server.io().running_in_this_thread());
+			ASIO2_CHECK(server.iopool().get(0).running_in_this_thread());
+		});
+
+		server.bind("echo", echo);
+
+		bool server_start_ret = server.start("127.0.0.1", 18010);
+
+		ASIO2_CHECK(server_start_ret);
+		ASIO2_CHECK(server.is_started());
+
+		ASIO2_CHECK_VALUE(server_init_counter      .load(), server_init_counter       == 1);
+		ASIO2_CHECK_VALUE(server_start_counter     .load(), server_start_counter      == 1);
+
+		std::vector<std::shared_ptr<my_rpc_kcp_client_kcp>> clients;
+		std::atomic<int> client_init_counter = 0;
+		std::atomic<int> client_connect_counter = 0;
+		std::atomic<int> client_disconnect_counter = 0;
+		std::atomic<int> client_start_failed_counter = 0;
+		for (int i = 0; i < test_client_count; i++)
+		{
+			auto iter = clients.emplace_back(std::make_shared<my_rpc_kcp_client_kcp>());
+
+			my_rpc_kcp_client_kcp& client = *iter;
+
+			// set default rpc call timeout
+			client.set_default_timeout(std::chrono::seconds(3));
+			ASIO2_CHECK(client.get_default_timeout() == std::chrono::seconds(3));
+			client.set_auto_reconnect(false);
+			ASIO2_CHECK(!client.is_auto_reconnect());
+
+			client.bind_init([&]()
+			{
+				client_init_counter++;
+
+				client.set_no_delay(true);
+
+				ASIO2_CHECK(client.io().running_in_this_thread());
+				ASIO2_CHECK(client.iopool().get(0).running_in_this_thread());
+				ASIO2_CHECK(!asio2::get_last_error());
+				ASIO2_CHECK(client.is_keep_alive());
+				ASIO2_CHECK(client.is_reuse_address());
+				ASIO2_CHECK(client.is_no_delay());
+			});
+			client.bind_connect([&]()
+			{
+				ASIO2_CHECK(client.io().running_in_this_thread());
+				ASIO2_CHECK(client.iopool().get(0).running_in_this_thread());
+				ASIO2_CHECK(!asio2::get_last_error());
+				ASIO2_CHECK(client.get_local_address() == "127.0.0.1");
+				ASIO2_CHECK(client.get_remote_address() == "127.0.0.1");
+				ASIO2_CHECK(client.get_remote_port() == 18010);
+				ASIO2_CHECK(client.is_started());
+
+				client_connect_counter++;
+
+			});
+			client.bind_disconnect([&]()
+			{
+				client_disconnect_counter++;
+
+				ASIO2_CHECK(asio2::get_last_error());
+				ASIO2_CHECK(client.io().running_in_this_thread());
+				ASIO2_CHECK(client.iopool().get(0).running_in_this_thread());
+			});
+			client.bind_recv([&]([[maybe_unused]] std::string_view data)
+			{
+				ASIO2_CHECK(!asio2::get_last_error());
+				ASIO2_CHECK(client.io().running_in_this_thread());
+				ASIO2_CHECK(client.iopool().get(0).running_in_this_thread());
+				ASIO2_CHECK(!data.empty());
+				ASIO2_CHECK(client.is_started());
+			});
+
+			bool client_start_ret = client.start("127.0.0.1", 18010);
+			if (!client_start_ret)
+				client_start_failed_counter++;
+			ASIO2_CHECK(client_start_ret);
+			ASIO2_CHECK(!asio2::get_last_error());
+		}
+
+		while (server.get_session_count() < std::size_t(test_client_count - client_start_failed_counter))
+		{
+			ASIO2_TEST_WAIT_CHECK();
+		}
+
+		auto session_count = server.get_session_count();
+		ASIO2_CHECK_VALUE(session_count, session_count == std::size_t(test_client_count));
+
+		ASIO2_CHECK_VALUE(server_accept_counter    .load(), server_accept_counter     == test_client_count);
+		ASIO2_CHECK_VALUE(server_connect_counter   .load(), server_connect_counter    == test_client_count);
+
+		while (client_connect_counter < test_client_count - client_start_failed_counter)
+		{
+			ASIO2_TEST_WAIT_CHECK();
+		}
+
+		ASIO2_CHECK_VALUE(client_init_counter      .load(), client_init_counter    == test_client_count);
+		ASIO2_CHECK_VALUE(client_connect_counter   .load(), client_connect_counter == test_client_count);
+
+		std::string msg;
+
+		while (client_disconnect_counter < test_client_count - client_start_failed_counter)
+		{
+			ASIO2_TEST_WAIT_CHECK(client_disconnect_counter, client_connect_counter, client_start_failed_counter);
+
+			msg.clear();
+			int len = 200 + (std::rand() % 200);
+			for (int i = 0; i < len; i++)
+			{
+				msg += (char)(std::rand() % 255);
+			}
+			// send random data to server for every client, if the data is invalid, the session will be closed
+			for (int i = 0; i < test_client_count; i++)
+			{
+				clients[i]->async_send(msg);
+			}
+		}
+
+		ASIO2_CHECK_VALUE(client_disconnect_counter.load(), client_disconnect_counter == test_client_count);
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			ASIO2_CHECK(!clients[i]->is_stopped());
+			ASIO2_CHECK(!clients[i]->is_started());
+		}
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			clients[i]->stop();
+			ASIO2_CHECK( clients[i]->is_stopped());
+			ASIO2_CHECK(!clients[i]->is_started());
+		}
+
+		ASIO2_CHECK_VALUE(client_disconnect_counter.load(), client_disconnect_counter == test_client_count);
+
+		// use this to ensure the ASIO2_CHECK(session_ptr->is_started());
+		while (server_disconnect_counter != test_client_count - client_start_failed_counter)
+		{
+			ASIO2_TEST_WAIT_CHECK();
+		}
+
+		server.stop();
+		ASIO2_CHECK(server.is_stopped());
+
+		ASIO2_CHECK_VALUE(server_disconnect_counter.load(), server_disconnect_counter == test_client_count);
+		ASIO2_CHECK_VALUE(server_stop_counter      .load(), server_stop_counter       == 1);
+
+		//-----------------------------------------------------------------------------------------
+
+		ASIO2_CHECK_VALUE(server.get_session_count(), server.get_session_count() == std::size_t(0));
+
+		server_init_counter = 0;
+		server_start_counter = 0;
+		server_disconnect_counter = 0;
+		server_stop_counter = 0;
+		server_accept_counter = 0;
+		server_connect_counter = 0;
+
+		server_start_ret = server.start("127.0.0.1", 18010);
+
+		ASIO2_CHECK(server_start_ret);
+		ASIO2_CHECK(server.is_started());
+
+		ASIO2_CHECK_VALUE(server_init_counter      .load(), server_init_counter       == 1);
+		ASIO2_CHECK_VALUE(server_start_counter     .load(), server_start_counter      == 1);
+
+		client_init_counter = 0;
+		client_connect_counter = 0;
+		client_disconnect_counter = 0;
+		client_start_failed_counter = 0;
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			bool client_start_ret = clients[i]->async_start("127.0.0.1", 18010);
+			ASIO2_CHECK(client_start_ret);
+			ASIO2_CHECK(asio2::get_last_error() == asio::error::in_progress);
+		}
+
+		while (server.get_session_count() < std::size_t(test_client_count - client_start_failed_counter))
+		{
+			ASIO2_TEST_WAIT_CHECK();
+		}
+
+		ASIO2_CHECK_VALUE(server.get_session_count(), server.get_session_count() == std::size_t(test_client_count));
+
+		ASIO2_CHECK_VALUE(server_accept_counter    .load(), server_accept_counter     == test_client_count);
+		ASIO2_CHECK_VALUE(server_connect_counter   .load(), server_connect_counter    == test_client_count);
+
+		while (client_connect_counter < test_client_count - client_start_failed_counter)
+		{
+			ASIO2_TEST_WAIT_CHECK();
+		}
+
+		ASIO2_CHECK_VALUE(client_init_counter      .load(), client_init_counter    == test_client_count);
+		ASIO2_CHECK_VALUE(client_connect_counter   .load(), client_connect_counter == test_client_count);
+
+		while (client_disconnect_counter < test_client_count - client_start_failed_counter)
+		{
+			ASIO2_TEST_WAIT_CHECK(client_disconnect_counter, client_connect_counter, client_start_failed_counter);
+
+			msg.clear();
+			int len = 200 + (std::rand() % 200);
+			for (int i = 0; i < len; i++)
+			{
+				msg += (char)(std::rand() % 255);
+			}
+			// send random data to server for every client, if the data is invalid, the session will be closed
+			for (int i = 0; i < test_client_count; i++)
+			{
+				clients[i]->async_send(msg);
+			}
+		}
+
+		ASIO2_CHECK_VALUE(client_disconnect_counter.load(), client_disconnect_counter == test_client_count);
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			ASIO2_CHECK(!clients[i]->is_stopped());
+			ASIO2_CHECK(!clients[i]->is_started());
+		}
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			clients[i]->stop();
+			ASIO2_CHECK( clients[i]->is_stopped());
+			ASIO2_CHECK(!clients[i]->is_started());
+		}
+
+		ASIO2_CHECK_VALUE(client_disconnect_counter.load(), client_disconnect_counter == test_client_count);
+
+		// use this to ensure the ASIO2_CHECK(session_ptr->is_started());
+		while (server_disconnect_counter != test_client_count - client_start_failed_counter)
+		{
+			ASIO2_TEST_WAIT_CHECK();
+		}
+
+		server.stop();
+		ASIO2_CHECK(server.is_stopped());
+
+		ASIO2_CHECK_VALUE(server_disconnect_counter.load(), server_disconnect_counter == test_client_count);
+		ASIO2_CHECK_VALUE(server_stop_counter      .load(), server_stop_counter       == 1);
+	}
+
+	// test max buffer size and auto reconnect
+	{
+		struct ext_data
+		{
+			int data_zie = 0;
+			int send_counter = 0;
+			int client_init_counter = 0;
+			int client_connect_counter = 0;
+			int client_disconnect_counter = 0;
+			std::chrono::high_resolution_clock::time_point start_time = std::chrono::high_resolution_clock::now();
+		};
+
+		asio2::rpc_kcp_server server(512, 1024, 4);
+
+		std::atomic<int> server_accept_counter = 0;
+		std::atomic<int> server_connect_counter = 0;
+		server.bind_connect([&](auto & session_ptr)
+		{
+			server_connect_counter++;
+
+			ASIO2_CHECK(!asio2::get_last_error());
+			ASIO2_CHECK(session_ptr->remote_address() == "127.0.0.1");
+			ASIO2_CHECK(session_ptr->local_address() == "127.0.0.1");
+			ASIO2_CHECK(session_ptr->local_port() == 18010);
+			ASIO2_CHECK(server.io().running_in_this_thread());
+			ASIO2_CHECK(server.iopool().get(0).running_in_this_thread());
+			ASIO2_CHECK(session_ptr->is_keep_alive());
+			ASIO2_CHECK(session_ptr->is_no_delay());
+
+		});
+		std::atomic<int> server_disconnect_counter = 0;
+		server.bind_disconnect([&](auto & session_ptr)
+		{
+			server_disconnect_counter++;
+
+			ASIO2_CHECK(asio2::get_last_error());
+			ASIO2_CHECK(session_ptr->socket().is_open());
+			ASIO2_CHECK(server.io().running_in_this_thread());
+			ASIO2_CHECK(server.iopool().get(0).running_in_this_thread());
+		});
+		std::atomic<int> server_init_counter = 0;
+		server.bind_init([&]()
+		{
+			server_init_counter++;
+
+			ASIO2_CHECK(!asio2::get_last_error());
+			ASIO2_CHECK(server.io().running_in_this_thread());
+			ASIO2_CHECK(server.iopool().get(0).running_in_this_thread());
+
+			asio::socket_base::reuse_address option;
+			server.acceptor().get_option(option);
+			ASIO2_CHECK(option.value());
+		});
+		std::atomic<int> server_start_counter = 0;
+		server.bind_start([&]()
+		{
+			server_start_counter++;
+
+			ASIO2_CHECK(!asio2::get_last_error());
+			ASIO2_CHECK(server.get_listen_address() == "127.0.0.1");
+			ASIO2_CHECK(server.get_listen_port() == 18010);
+			ASIO2_CHECK(server.io().running_in_this_thread());
+			ASIO2_CHECK(server.iopool().get(0).running_in_this_thread());
+		});
+		std::atomic<int> server_stop_counter = 0;
+		server.bind_stop([&]()
+		{
+			server_stop_counter++;
+
+			ASIO2_CHECK(asio2::get_last_error());
+			ASIO2_CHECK(server.get_listen_address() == "127.0.0.1");
+			ASIO2_CHECK(server.get_listen_port() == 18010);
+			ASIO2_CHECK(server.io().running_in_this_thread());
+			ASIO2_CHECK(server.iopool().get(0).running_in_this_thread());
+		});
+
+		server.bind("echo", echo);
+
+		bool server_start_ret = server.start("127.0.0.1", 18010);
+
+		ASIO2_CHECK(server_start_ret);
+		ASIO2_CHECK(server.is_started());
+
+		ASIO2_CHECK_VALUE(server_init_counter      .load(), server_init_counter       == 1);
+		ASIO2_CHECK_VALUE(server_start_counter     .load(), server_start_counter      == 1);
+
+		std::vector<std::shared_ptr<asio2::rpc_kcp_client>> clients;
+		for (int i = 0; i < test_client_count; i++)
+		{
+			auto iter = clients.emplace_back(std::make_shared<asio2::rpc_kcp_client>());
+
+			asio2::rpc_kcp_client& client = *iter;
+
+			// set default rpc call timeout
+			client.set_default_timeout(std::chrono::seconds(3));
+			ASIO2_CHECK(client.get_default_timeout() == std::chrono::seconds(3));
+			client.set_connect_timeout(std::chrono::milliseconds(100));
+			client.set_auto_reconnect(true, std::chrono::milliseconds(100));
+			ASIO2_CHECK(client.is_auto_reconnect());
+			ASIO2_CHECK(client.get_auto_reconnect_delay() == std::chrono::milliseconds(100));
+			ASIO2_CHECK(client.get_connect_timeout() == std::chrono::milliseconds(100));
+
+			client.bind_init([&]()
+			{
+				ext_data& ex = client.get_user_data<ext_data&>();
+				ex.client_init_counter++;
+
+				client.set_no_delay(true);
+
+				ASIO2_CHECK(client.io().running_in_this_thread());
+				ASIO2_CHECK(client.iopool().get(0).running_in_this_thread());
+				ASIO2_CHECK(!asio2::get_last_error());
+				ASIO2_CHECK(client.is_keep_alive());
+				ASIO2_CHECK(client.is_reuse_address());
+				ASIO2_CHECK(client.is_no_delay());
+			});
+			client.bind_connect([&]()
+			{
+				if (asio2::get_last_error())
+					return;
+
+				ASIO2_CHECK(client.io().running_in_this_thread());
+				ASIO2_CHECK(client.iopool().get(0).running_in_this_thread());
+				ASIO2_CHECK(!asio2::get_last_error());
+				ASIO2_CHECK(client.get_local_address() == "127.0.0.1");
+				ASIO2_CHECK(client.get_remote_address() == "127.0.0.1");
+				ASIO2_CHECK(client.get_remote_port() == 18010);
+
+				ext_data& ex = client.get_user_data<ext_data&>();
+
+				std::string msg;
+				msg.resize(ex.data_zie);
+				client.async_call("echo", msg).response([&client](std::string s)
+				{
+					ext_data& ex = client.get_user_data<ext_data&>();
+					ex.send_counter++;
+
+					if (ex.data_zie <= 1024)
+					{
+						ASIO2_CHECK(!s.empty());
+						ASIO2_CHECK_VALUE(asio2::last_error_msg(), !asio2::get_last_error());
+					}
+					else
+					{
+						ASIO2_CHECK(s.empty());
+						// when send data failed, the error is not rpc::error::operation_aborted,
+						// and the server can't recv the illage data, and the server will can't
+						// disconnect this client, this will cause client_connect_counter can't 
+						// be equal to 3.
+						if (asio2::get_last_error() != rpc::error::operation_aborted)
+						{
+							// close the socket, this will trigger the auto reconnect
+							client.socket().close();
+						}
+					}
+				});
+
+				ex.client_connect_counter++;
+
+				if (ex.client_connect_counter == 1)
+				{
+					auto elapse1 = std::abs(std::chrono::duration_cast<std::chrono::milliseconds>(
+						std::chrono::high_resolution_clock::now() - ex.start_time).count() - 100);
+					ASIO2_CHECK_VALUE(elapse1, elapse1 <= test_timer_deviation);
+				}
+				else
+				{
+					auto elapse1 = std::abs(std::chrono::duration_cast<std::chrono::milliseconds>(
+						std::chrono::high_resolution_clock::now() - ex.start_time).count() - 200);
+					ASIO2_CHECK_VALUE(elapse1, elapse1 <= test_timer_deviation);
+				}
+
+				ex.start_time = std::chrono::high_resolution_clock::now();
+
+				if (ex.client_connect_counter == 3)
+				{
+					client.set_auto_reconnect(false);
+					ASIO2_CHECK(!client.is_auto_reconnect());
+				}
+
+			});
+			client.bind_disconnect([&]()
+			{
+				ext_data& ex = client.get_user_data<ext_data&>();
+				ex.client_disconnect_counter++;
+
+				ASIO2_CHECK(asio2::get_last_error());
+				ASIO2_CHECK(client.io().running_in_this_thread());
+				ASIO2_CHECK(client.iopool().get(0).running_in_this_thread());
+			});
+			client.bind_recv([&]([[maybe_unused]] std::string_view data)
+			{
+				ASIO2_CHECK(!asio2::get_last_error());
+				ASIO2_CHECK(client.io().running_in_this_thread());
+				ASIO2_CHECK(client.iopool().get(0).running_in_this_thread());
+				ASIO2_CHECK(!data.empty());
+				ASIO2_CHECK(client.is_started());
+			});
+
+			ext_data ex;
+			ex.data_zie = 1500;
+
+			client.set_user_data(std::move(ex));
+
+			bool client_start_ret = client.start("127.0.0.1", 18010);
+			ASIO2_CHECK(client_start_ret);
+			ASIO2_CHECK(!asio2::get_last_error());
+		}
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			ext_data& ex = clients[i]->get_user_data<ext_data&>();
+			while (ex.client_connect_counter < 3)
+			{
+				ASIO2_TEST_WAIT_CHECK();
+			}
+		}
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			ext_data& ex = clients[i]->get_user_data<ext_data&>();
+			ASIO2_CHECK_VALUE(ex.client_init_counter, ex.client_init_counter == 3);
+			ASIO2_CHECK_VALUE(ex.client_connect_counter, ex.client_connect_counter == 3);
+		}
+
+		while (server_connect_counter < test_client_count * 3)
+		{
+			ASIO2_TEST_WAIT_CHECK();
+		}
+
+		ASIO2_CHECK_VALUE(server_accept_counter    .load(), server_accept_counter     == test_client_count * 3);
+		ASIO2_CHECK_VALUE(server_connect_counter   .load(), server_connect_counter    == test_client_count * 3);
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			ext_data& ex = clients[i]->get_user_data<ext_data&>();
+			while (ex.client_disconnect_counter < 3)
+			{
+				ASIO2_TEST_WAIT_CHECK();
+			}
+		}
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			ASIO2_CHECK(!clients[i]->is_stopped());
+			ASIO2_CHECK(!clients[i]->is_started());
+		}
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			ext_data& ex = clients[i]->get_user_data<ext_data&>();
+			ASIO2_CHECK_VALUE(ex.client_disconnect_counter, ex.client_disconnect_counter == 3);
+		}
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			clients[i]->stop();
+			ASIO2_CHECK( clients[i]->is_stopped());
+			ASIO2_CHECK(!clients[i]->is_started());
+			ASIO2_CHECK(!clients[i]->user_data_any().has_value());
+		}
+
+		// use this to ensure the ASIO2_CHECK(session_ptr->is_started());
+		//while (server_disconnect_counter != test_client_count * 3)
+		while (server_disconnect_counter < test_client_count * 3)
+		{
+			ASIO2_TEST_WAIT_CHECK();
+		}
+
+		server.stop();
+		ASIO2_CHECK(server.is_stopped());
+
+		ASIO2_CHECK_VALUE(server_disconnect_counter.load(), server_disconnect_counter == test_client_count*3);
+		ASIO2_CHECK_VALUE(server_stop_counter      .load(), server_stop_counter       == 1);
+
+		//-----------------------------------------------------------------------------------------
+
+		ASIO2_CHECK_VALUE(server.get_session_count(), server.get_session_count() == std::size_t(0));
+
+		server_init_counter = 0;
+		server_start_counter = 0;
+		server_disconnect_counter = 0;
+		server_stop_counter = 0;
+		server_accept_counter = 0;
+		server_connect_counter = 0;
+
+		server_start_ret = server.start("127.0.0.1", 18010);
+
+		ASIO2_CHECK(server_start_ret);
+		ASIO2_CHECK(server.is_started());
+
+		ASIO2_CHECK_VALUE(server_init_counter      .load(), server_init_counter       == 1);
+		ASIO2_CHECK_VALUE(server_start_counter     .load(), server_start_counter      == 1);
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			asio2::rpc_kcp_client& client = *clients[i];
+
+			ASIO2_CHECK(client.get_default_timeout() == std::chrono::seconds(3));
+			client.set_auto_reconnect(true, std::chrono::milliseconds(100));
+			ASIO2_CHECK(client.is_auto_reconnect());
+			ASIO2_CHECK(client.get_auto_reconnect_delay() == std::chrono::milliseconds(100));
+			ASIO2_CHECK(client.get_connect_timeout() == std::chrono::milliseconds(100));
+
+			ext_data ex;
+			ex.data_zie = 500;
+
+			client.set_user_data(std::move(ex));
+
+			bool client_start_ret = client.start("127.0.0.1", 18010);
+			ASIO2_CHECK(client_start_ret);
+			ASIO2_CHECK(!asio2::get_last_error());
+		}
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			ext_data& ex = clients[i]->get_user_data<ext_data&>();
+			while (ex.client_connect_counter < 1)
+			{
+				ASIO2_TEST_WAIT_CHECK();
+			}
+		}
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			ext_data& ex = clients[i]->get_user_data<ext_data&>();
+			ASIO2_CHECK_VALUE(ex.client_init_counter, ex.client_init_counter == 1);
+			ASIO2_CHECK_VALUE(ex.client_connect_counter, ex.client_connect_counter == 1);
+		}
+
+		while (server_connect_counter < test_client_count * 1)
+		{
+			ASIO2_TEST_WAIT_CHECK();
+		}
+
+		ASIO2_CHECK_VALUE(server_accept_counter    .load(), server_accept_counter     == test_client_count * 1);
+		ASIO2_CHECK_VALUE(server_connect_counter   .load(), server_connect_counter    == test_client_count * 1);
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			ASIO2_CHECK(!clients[i]->is_stopped());
+			ASIO2_CHECK( clients[i]->is_started());
+		}
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			ext_data& ex = clients[i]->get_user_data<ext_data&>();
+			while (ex.send_counter < 1)
+			{
+				ASIO2_TEST_WAIT_CHECK();
+			}
+		}
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			clients[i]->stop();
+			ASIO2_CHECK( clients[i]->is_stopped());
+			ASIO2_CHECK(!clients[i]->is_started());
+			ASIO2_CHECK(!clients[i]->user_data_any().has_value());
+		}
+
+		// use this to ensure the ASIO2_CHECK(session_ptr->is_started());
+		while (server_disconnect_counter != test_client_count * 1)
+		{
+			ASIO2_TEST_WAIT_CHECK();
+		}
+
+		server.stop();
+		ASIO2_CHECK(server.is_stopped());
+
+		ASIO2_CHECK_VALUE(server_disconnect_counter.load(), server_disconnect_counter == test_client_count*1);
+		ASIO2_CHECK_VALUE(server_stop_counter      .load(), server_stop_counter       == 1);
+	}
+
+	// test rpc function
+	{
+		struct ext_data
+		{
+			int async_call_counter = 0;
+			int sync_call_counter = 0;
+			int client_init_counter = 0;
+			int client_connect_counter = 0;
+			int client_disconnect_counter = 0;
+		};
+
+		asio2::rpc_kcp_server server;
+
+		std::atomic<int> server_accept_counter = 0;
+		std::atomic<int> server_async_call_counter = 0;
+		std::atomic<int> server_connect_counter = 0;
+		server.bind_connect([&](auto & session_ptr)
+		{
+			server_connect_counter++;
+
+			session_ptr->async_call([&, session_ptr](int v)
+			{
+				server_async_call_counter++;
+				ASIO2_CHECK(session_ptr->io().running_in_this_thread());
+				ASIO2_CHECK(!asio2::get_last_error());
+				ASIO2_CHECK(v == 15 - 6);
+			}, std::chrono::seconds(10), "sub", 15, 6);
+
+			session_ptr->async_call("test", "i love you");
+
+			ASIO2_CHECK(!asio2::get_last_error());
+			ASIO2_CHECK(session_ptr->remote_address() == "127.0.0.1");
+			ASIO2_CHECK(session_ptr->local_address() == "127.0.0.1");
+			ASIO2_CHECK(session_ptr->local_port() == 18010);
+			ASIO2_CHECK(server.io().running_in_this_thread());
+			ASIO2_CHECK(server.iopool().get(0).running_in_this_thread());
+			ASIO2_CHECK(session_ptr->is_keep_alive());
+			ASIO2_CHECK(session_ptr->is_no_delay());
+
+		});
+		std::atomic<int> server_disconnect_counter = 0;
+		server.bind_disconnect([&](auto & session_ptr)
+		{
+			server_disconnect_counter++;
+
+			ASIO2_CHECK(asio2::get_last_error());
+			ASIO2_CHECK(session_ptr->socket().is_open());
+			ASIO2_CHECK(server.io().running_in_this_thread());
+			ASIO2_CHECK(server.iopool().get(0).running_in_this_thread());
+		});
+		std::atomic<int> server_init_counter = 0;
+		server.bind_init([&]()
+		{
+			server_init_counter++;
+
+			ASIO2_CHECK(!asio2::get_last_error());
+			ASIO2_CHECK(server.io().running_in_this_thread());
+			ASIO2_CHECK(server.iopool().get(0).running_in_this_thread());
+
+			asio::socket_base::reuse_address option;
+			server.acceptor().get_option(option);
+			ASIO2_CHECK(option.value());
+		});
+		std::atomic<int> server_start_counter = 0;
+		server.bind_start([&]()
+		{
+			server_start_counter++;
+
+			ASIO2_CHECK(!asio2::get_last_error());
+			ASIO2_CHECK(server.get_listen_address() == "127.0.0.1");
+			ASIO2_CHECK(server.get_listen_port() == 18010);
+			ASIO2_CHECK(server.io().running_in_this_thread());
+			ASIO2_CHECK(server.iopool().get(0).running_in_this_thread());
+		});
+		std::atomic<int> server_stop_counter = 0;
+		server.bind_stop([&]()
+		{
+			server_stop_counter++;
+
+			ASIO2_CHECK(asio2::get_last_error());
+			ASIO2_CHECK(server.get_listen_address() == "127.0.0.1");
+			ASIO2_CHECK(server.get_listen_port() == 18010);
+			ASIO2_CHECK(server.io().running_in_this_thread());
+			ASIO2_CHECK(server.iopool().get(0).running_in_this_thread());
+		});
+
+		server.bind("echo", echo);
+
+		usercrud crud;
+
+		server
+			.bind("add", add)
+			.bind("mul", &usercrud::mul, crud)
+			.bind("get_user", &usercrud::get_user, crud)
+			.bind("del_user", &usercrud::del_user, &crud);
+
+		server.bind("async_add", async_add);
+		server.bind("async_test", async_test);
+
+		server.bind("test_json", test_json);
+		server.bind("heartbeat", heartbeat);
+
+		server.bind("cat", [&](std::shared_ptr<asio2::rpc_kcp_session>& session_ptr,
+			const std::string& a, const std::string& b)
+		{
+			ASIO2_CHECK(session_ptr->io().running_in_this_thread());
+			ASIO2_CHECK(!asio2::get_last_error());
+
+			// Nested call rpc function in business function is ok.
+			session_ptr->async_call([&, session_ptr](int v) mutable
+			{
+				server_async_call_counter++;
+
+				ASIO2_CHECK(session_ptr->io().running_in_this_thread());
+				ASIO2_CHECK(!asio2::get_last_error());
+				ASIO2_CHECK(v == 15 - 8);
+
+				// Nested call rpc function in business function is ok.
+				session_ptr->async_call([&, session_ptr](int v)
+				{
+					server_async_call_counter++;
+					ASIO2_CHECK(session_ptr->io().running_in_this_thread());
+					ASIO2_CHECK(!asio2::get_last_error());
+					ASIO2_CHECK(v == 15 + 18);
+				}, "async_add", 15, 18);
+
+			}, "sub", 15, 8);
+
+			return a + b;
+		});
+
+		bool server_start_ret = server.start("127.0.0.1", 18010);
+
+		ASIO2_CHECK(server_start_ret);
+		ASIO2_CHECK(server.is_started());
+
+		ASIO2_CHECK_VALUE(server_init_counter      .load(), server_init_counter       == 1);
+		ASIO2_CHECK_VALUE(server_start_counter     .load(), server_start_counter      == 1);
+
+		std::vector<std::shared_ptr<asio2::rpc_kcp_client>> clients;
+		for (int i = 0; i < test_client_count; i++)
+		{
+			auto iter = clients.emplace_back(std::make_shared<asio2::rpc_kcp_client>());
+
+			asio2::rpc_kcp_client& client = *iter;
+
+			// set default rpc call timeout
+			client.set_default_timeout(std::chrono::seconds(3));
+			ASIO2_CHECK(client.get_default_timeout() == std::chrono::seconds(3));
+			client.set_auto_reconnect(false);
+			ASIO2_CHECK(!client.is_auto_reconnect());
+
+			client.bind_init([&]()
+			{
+				ext_data& ex = client.get_user_data<ext_data&>();
+				ex.client_init_counter++;
+
+				client.set_no_delay(true);
+
+				ASIO2_CHECK(client.io().running_in_this_thread());
+				ASIO2_CHECK(client.iopool().get(0).running_in_this_thread());
+				ASIO2_CHECK(!asio2::get_last_error());
+				ASIO2_CHECK(client.is_keep_alive());
+				ASIO2_CHECK(client.is_reuse_address());
+				ASIO2_CHECK(client.is_no_delay());
+			});
+			client.bind_connect([&]()
+			{
+				if (asio2::get_last_error())
+					return;
+
+				ASIO2_CHECK(client.io().running_in_this_thread());
+				ASIO2_CHECK(client.iopool().get(0).running_in_this_thread());
+				ASIO2_CHECK(!asio2::get_last_error());
+				ASIO2_CHECK(client.get_local_address() == "127.0.0.1");
+				ASIO2_CHECK(client.get_remote_address() == "127.0.0.1");
+				ASIO2_CHECK(client.get_remote_port() == 18010);
+
+				ext_data& ex = client.get_user_data<ext_data&>();
+				ex.client_connect_counter++;
+
+				//------------------------------------------------------------------
+				client.call<double>("mul", 16.5, 26.5);
+				ASIO2_CHECK(asio2::get_last_error() == rpc::error::in_progress);
+
+				client.async_call([&](int v)
+				{
+					ASIO2_CHECK(client.io().running_in_this_thread());
+					ASIO2_CHECK(!asio2::get_last_error());
+					ASIO2_CHECK(v == 12 + 11);
+					ex.async_call_counter++;
+				}, std::chrono::seconds(13), "add", 12, 11);
+
+				client.async_call([&]()
+				{
+					ASIO2_CHECK(client.io().running_in_this_thread());
+					ASIO2_CHECK(!asio2::get_last_error());
+					ex.async_call_counter++;
+				}, std::chrono::seconds(3), "heartbeat");
+
+				nlohmann::json j = nlohmann::json::object();
+
+				j["name"] = "lilei";
+				j["age"] = 30;
+
+				client.async_call("test_json", j).response([&](nlohmann::json js)
+				{
+					ASIO2_CHECK(client.io().running_in_this_thread());
+					ASIO2_CHECK(!asio2::get_last_error());
+					ex.async_call_counter++;
+
+					std::string s = js.dump();
+
+					ASIO2_CHECK(js["age"].get<int>() == 30);
+					ASIO2_CHECK(js["name"].get<std::string>() == "lilei");
+
+					asio2::ignore_unused(js, s);
+				});
+
+				// param 2 is empty, use the default_timeout
+				client.async_call([&](int v)
+				{
+					ASIO2_CHECK(client.io().running_in_this_thread());
+					ASIO2_CHECK(!asio2::get_last_error());
+					ASIO2_CHECK(v == 12 + 21);
+					ex.async_call_counter++;
+				}, "add", 12, 21);
+
+				// param 1 is empty, the result of the rpc call is not returned
+				client.async_call("mul0", 2.5, 2.5);
+
+				// Chain calls : 
+				client.set_timeout(std::chrono::seconds(5)).async_call("mul", 2.5, 2.5).response([&](double v)
+				{
+					ASIO2_CHECK(client.io().running_in_this_thread());
+					ASIO2_CHECK(!asio2::get_last_error());
+					ASIO2_CHECK(v == 2.5 * 2.5);
+					ex.async_call_counter++;
+				});
+
+				// Chain calls : 
+				client.timeout(std::chrono::seconds(13)).response([&](double v)
+				{
+					ASIO2_CHECK(client.io().running_in_this_thread());
+					ASIO2_CHECK(!asio2::get_last_error());
+					ASIO2_CHECK(v == 3.5 * 3.5);
+					ex.async_call_counter++;
+				}).async_call("mul", 3.5, 3.5);
+
+				// Chain calls : 
+				client.response([&](double v)
+				{
+					ASIO2_CHECK(client.io().running_in_this_thread());
+					ASIO2_CHECK(!asio2::get_last_error());
+					ASIO2_CHECK(v == 4.5 * 4.5);
+					ex.async_call_counter++;
+				}).timeout(std::chrono::seconds(5)).async_call("mul", 4.5, 4.5);
+
+				// Chain calls : 
+				client.async_call("mul", 5.5, 5.5).response([&](double v)
+				{
+					ASIO2_CHECK(client.io().running_in_this_thread());
+					ASIO2_CHECK(!asio2::get_last_error());
+					ASIO2_CHECK(v == 5.5 * 5.5);
+					ex.async_call_counter++;
+				}).timeout(std::chrono::seconds(10));
+
+				client.async_call([&](int v)
+				{
+					ASIO2_CHECK(client.io().running_in_this_thread());
+					ASIO2_CHECK(!asio2::get_last_error());
+					ASIO2_CHECK(v == 1 + 11);
+					ex.async_call_counter++;
+				}, std::chrono::seconds(3), "async_add", 1, 11);
+
+				client.async_call([&]()
+				{
+					ASIO2_CHECK(client.io().running_in_this_thread());
+					ASIO2_CHECK(!asio2::get_last_error());
+					ex.async_call_counter++;
+				}, std::chrono::seconds(3), "async_test", "abc", "def");
+
+			});
+			client.bind_disconnect([&]()
+			{
+				ext_data& ex = client.get_user_data<ext_data&>();
+				ex.client_disconnect_counter++;
+
+				ASIO2_CHECK(asio2::get_last_error());
+				ASIO2_CHECK(client.io().running_in_this_thread());
+				ASIO2_CHECK(client.iopool().get(0).running_in_this_thread());
+			});
+			client.bind_recv([&]([[maybe_unused]] std::string_view data)
+			{
+				ASIO2_CHECK(!asio2::get_last_error());
+				ASIO2_CHECK(client.io().running_in_this_thread());
+				ASIO2_CHECK(client.iopool().get(0).running_in_this_thread());
+				ASIO2_CHECK(!data.empty());
+				ASIO2_CHECK(client.is_started());
+			});
+
+			// bind a rpc function in client, the server will call this client's rpc function
+			client.bind("sub", [](int a, int b) { return a - b; });
+
+			client.bind("async_add", async_add);
+
+			client.bind("test", client_fn_test);
+
+			ext_data ex;
+
+			client.set_user_data(std::move(ex));
+
+			bool client_start_ret = client.start("127.0.0.1", 18010);
+
+			ASIO2_CHECK(client_start_ret);
+			ASIO2_CHECK(!asio2::get_last_error());
+
+			nlohmann::json j = nlohmann::json::object();
+
+			j["name"] = "hanmeimei";
+			j["age"] = 20;
+
+			nlohmann::json j2 = client.call<nlohmann::json>(std::chrono::minutes(1), "test_json", j);
+			ASIO2_CHECK(!asio2::get_last_error());
+			ASIO2_CHECK(j2["age"].get<int>() == 20);
+			ASIO2_CHECK(j2["name"].get<std::string>() == "hanmeimei");
+
+			double mul = client.call<double>(std::chrono::seconds(3), "mul", 6.5, 6.5);
+			ASIO2_CHECK(!asio2::get_last_error());
+			ASIO2_CHECK(mul == 6.5 * 6.5);
+
+			userinfo u;
+			u = client.call<userinfo>("get_user");
+			ASIO2_CHECK(!asio2::get_last_error());
+			ASIO2_CHECK(u.name == "lilei" && u.age == 32 && u.purview.size() == 2);
+			for (auto &[k, v] : u.purview)
+			{
+				ASIO2_CHECK(k == 1 || k == 2);
+				if (k == 1) ASIO2_CHECK(v == "read");
+				if (k == 2) ASIO2_CHECK(v == "write");
+			}
+
+			u.name = "hanmeimei";
+			u.age = 33;
+			u.purview = { {10,"get"},{20,"set"} };
+			client.async_call([&]()
+			{
+				ASIO2_CHECK(client.io().running_in_this_thread());
+				ASIO2_CHECK(client.iopool().get(0).running_in_this_thread());
+				ASIO2_CHECK(!asio2::get_last_error());
+				ext_data& ex = client.get_user_data<ext_data&>();
+				ex.async_call_counter++;
+			}, "del_user", u);
+	
+
+			// just call rpc function, don't need the rpc result
+			client.async_call("del_user", u);
+
+			// this call will be failed, beacuse the param is incorrect.
+			client.async_call("del_user", "hanmeimei").response([&](userinfo)
+			{
+				ASIO2_CHECK(client.io().running_in_this_thread());
+				ASIO2_CHECK(client.iopool().get(0).running_in_this_thread());
+				ASIO2_CHECK(asio2::get_last_error() == rpc::error::invalid_argument);
+				ext_data& ex = client.get_user_data<ext_data&>();
+				ex.async_call_counter++;
+			});
+
+			// this call will be failed, beacuse the param is incorrect.
+			client.async_call("del_user", 10, std::string("lilei"), 1).response([&](userinfo)
+			{
+				ASIO2_CHECK(client.io().running_in_this_thread());
+				ASIO2_CHECK(client.iopool().get(0).running_in_this_thread());
+				ASIO2_CHECK(asio2::get_last_error() == rpc::error::invalid_argument);
+				ext_data& ex = client.get_user_data<ext_data&>();
+				ex.async_call_counter++;
+			});
+
+			// this call will be failed, beacuse the param is incorrect.
+			client.async_call("del_user", u, std::string("lilei"), 1).response([&](userinfo)
+			{
+				ASIO2_CHECK(client.io().running_in_this_thread());
+				ASIO2_CHECK(client.iopool().get(0).running_in_this_thread());
+				ASIO2_CHECK(asio2::get_last_error() == rpc::error::invalid_argument);
+				ext_data& ex = client.get_user_data<ext_data&>();
+				ex.async_call_counter++;
+			});
+
+			// Chain calls : 
+			int sum = client.timeout(std::chrono::seconds(13)).call<int>("add", 11, 12);
+			ASIO2_CHECK(!asio2::get_last_error());
+			ASIO2_CHECK(sum == 11 + 12);
+
+			// Chain calls : 
+			sum = client.timeout(std::chrono::seconds(13)).call<int>("add", 11, 32);
+			ASIO2_CHECK(!asio2::get_last_error());
+			ASIO2_CHECK(sum == 11 + 32);
+
+			sum = client.timeout(std::chrono::seconds(13)).call<int>("add", 11);
+			ASIO2_CHECK(asio2::get_last_error() == rpc::error::invalid_argument);
+			ASIO2_CHECK(sum == 0);
+
+			sum = client.timeout(std::chrono::seconds(13)).call<int>("add", 11, 12, 13);
+			ASIO2_CHECK(asio2::get_last_error() == rpc::error::invalid_argument);
+			ASIO2_CHECK(sum == 0);
+
+			sum = client.timeout(std::chrono::seconds(13)).call<int>("add", "11", 12, 13);
+			ASIO2_CHECK(asio2::get_last_error() == rpc::error::invalid_argument);
+			ASIO2_CHECK(sum == 0);
+
+			// Chain calls : 
+			std::string str = client.call<std::string>("cat", "abc", "123");
+			ASIO2_CHECK(!asio2::get_last_error());
+			ASIO2_CHECK(str == "abc123");
+
+			client.async_call([&](int)
+			{
+				ASIO2_CHECK(client.io().running_in_this_thread());
+				ASIO2_CHECK(client.iopool().get(0).running_in_this_thread());
+				ASIO2_CHECK(asio2::get_last_error() == rpc::error::not_found);
+				ext_data& ex = client.get_user_data<ext_data&>();
+				ex.async_call_counter++;
+			}, "no_exists_fn", 10);
+
+			sum = client.timeout(std::chrono::seconds(13)).call<int>("no_exists_fn", 12, 13);
+			ASIO2_CHECK(asio2::get_last_error() == rpc::error::not_found);
+			ASIO2_CHECK(sum == 0);
+		}
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			ext_data& ex = clients[i]->get_user_data<ext_data&>();
+			while (ex.client_connect_counter < 1)
+			{
+				ASIO2_TEST_WAIT_CHECK();
+			}
+		}
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			ext_data& ex = clients[i]->get_user_data<ext_data&>();
+			ASIO2_CHECK_VALUE(ex.client_init_counter, ex.client_init_counter == 1);
+			ASIO2_CHECK_VALUE(ex.client_connect_counter, ex.client_connect_counter == 1);
+		}
+
+		while (server_connect_counter < test_client_count * 1)
+		{
+			ASIO2_TEST_WAIT_CHECK();
+		}
+
+		ASIO2_CHECK_VALUE(server_accept_counter    .load(), server_accept_counter     == test_client_count * 1);
+		ASIO2_CHECK_VALUE(server_connect_counter   .load(), server_connect_counter    == test_client_count * 1);
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			ASIO2_CHECK(!clients[i]->is_stopped());
+			ASIO2_CHECK( clients[i]->is_started());
+		}
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			ext_data& ex = clients[i]->get_user_data<ext_data&>();
+			while (ex.async_call_counter < 15)
+			{
+				ASIO2_TEST_WAIT_CHECK();
+			}
+		}
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			ext_data& ex = clients[i]->get_user_data<ext_data&>();
+			ASIO2_CHECK_VALUE(ex.async_call_counter, ex.async_call_counter == 15);
+		}
+
+		while (server_async_call_counter < test_client_count * 3)
+		{
+			ASIO2_TEST_WAIT_CHECK();
+		}
+
+		ASIO2_CHECK_VALUE(server_async_call_counter.load(), server_async_call_counter == test_client_count * 3);
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			clients[i]->stop();
+			ASIO2_CHECK( clients[i]->is_stopped());
+			ASIO2_CHECK(!clients[i]->is_started());
+			ASIO2_CHECK(!clients[i]->user_data_any().has_value());
+		}
+
+		// use this to ensure the ASIO2_CHECK(session_ptr->is_started());
+		while (server_disconnect_counter != test_client_count * 1)
+		{
+			ASIO2_TEST_WAIT_CHECK();
+		}
+
+		server.stop();
+		ASIO2_CHECK(server.is_stopped());
+
+		ASIO2_CHECK_VALUE(server_disconnect_counter.load(), server_disconnect_counter == test_client_count*1);
+		ASIO2_CHECK_VALUE(server_stop_counter      .load(), server_stop_counter       == 1);
+
+		//-----------------------------------------------------------------------------------------
+
+		ASIO2_CHECK_VALUE(server.get_session_count(), server.get_session_count() == std::size_t(0));
+
+		server_init_counter = 0;
+		server_start_counter = 0;
+		server_disconnect_counter = 0;
+		server_stop_counter = 0;
+		server_accept_counter = 0;
+		server_connect_counter = 0;
+		server_async_call_counter = 0;
+
+		server_start_ret = server.start("127.0.0.1", 18010);
+
+		ASIO2_CHECK(server_start_ret);
+		ASIO2_CHECK(server.is_started());
+
+		ASIO2_CHECK_VALUE(server_init_counter      .load(), server_init_counter       == 1);
+		ASIO2_CHECK_VALUE(server_start_counter     .load(), server_start_counter      == 1);
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			asio2::rpc_kcp_client& client = *clients[i];
+
+			ASIO2_CHECK(client.get_default_timeout() == std::chrono::seconds(3));
+			client.set_auto_reconnect(true, std::chrono::milliseconds(100));
+			ASIO2_CHECK(client.is_auto_reconnect());
+			ASIO2_CHECK(client.get_auto_reconnect_delay() == std::chrono::milliseconds(100));
+
+			ext_data ex;
+
+			client.set_user_data(std::move(ex));
+
+			bool client_start_ret = client.async_start("127.0.0.1", 18010);
+			ASIO2_CHECK(client_start_ret);
+			ASIO2_CHECK(asio2::get_last_error() == asio::error::in_progress);
+		}
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			ext_data& ex = clients[i]->get_user_data<ext_data&>();
+			while (ex.client_connect_counter < 1)
+			{
+				ASIO2_TEST_WAIT_CHECK();
+			}
+		}
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			ext_data& ex = clients[i]->get_user_data<ext_data&>();
+			ASIO2_CHECK_VALUE(ex.client_init_counter, ex.client_init_counter == 1);
+			ASIO2_CHECK_VALUE(ex.client_connect_counter, ex.client_connect_counter == 1);
+		}
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			ASIO2_CHECK(!clients[i]->is_stopped());
+			ASIO2_CHECK( clients[i]->is_started());
+		}
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			asio2::rpc_kcp_client& client = *clients[i];
+
+			nlohmann::json j = nlohmann::json::object();
+
+			j["name"] = "hanmeimei";
+			j["age"] = 20;
+
+			nlohmann::json j2 = client.call<nlohmann::json>(std::chrono::minutes(1), "test_json", j);
+			ASIO2_CHECK(!asio2::get_last_error());
+			ASIO2_CHECK(j2["age"].get<int>() == 20);
+			ASIO2_CHECK(j2["name"].get<std::string>() == "hanmeimei");
+
+			double mul = client.call<double>(std::chrono::seconds(3), "mul", 6.5, 6.5);
+			ASIO2_CHECK(!asio2::get_last_error());
+			ASIO2_CHECK(mul == 6.5 * 6.5);
+
+			userinfo u;
+			u = client.call<userinfo>("get_user");
+			ASIO2_CHECK(!asio2::get_last_error());
+			ASIO2_CHECK(u.name == "lilei" && u.age == 32 && u.purview.size() == 2);
+			for (auto &[k, v] : u.purview)
+			{
+				ASIO2_CHECK(k == 1 || k == 2);
+				if (k == 1) ASIO2_CHECK(v == "read");
+				if (k == 2) ASIO2_CHECK(v == "write");
+			}
+
+			u.name = "hanmeimei";
+			u.age = 33;
+			u.purview = { {10,"get"},{20,"set"} };
+			client.async_call([&]()
+			{
+				ASIO2_CHECK(client.io().running_in_this_thread());
+				ASIO2_CHECK(client.iopool().get(0).running_in_this_thread());
+				ASIO2_CHECK(!asio2::get_last_error());
+				ext_data& ex = client.get_user_data<ext_data&>();
+				ex.async_call_counter++;
+			}, "del_user", u);
+	
+
+			// just call rpc function, don't need the rpc result
+			client.async_call("del_user", u);
+
+			// this call will be failed, beacuse the param is incorrect.
+			client.async_call("del_user", "hanmeimei").response([&](userinfo)
+			{
+				ASIO2_CHECK(client.io().running_in_this_thread());
+				ASIO2_CHECK(client.iopool().get(0).running_in_this_thread());
+				ASIO2_CHECK(asio2::get_last_error() == rpc::error::invalid_argument);
+				ext_data& ex = client.get_user_data<ext_data&>();
+				ex.async_call_counter++;
+			});
+
+			// this call will be failed, beacuse the param is incorrect.
+			client.async_call("del_user", 10, std::string("lilei"), 1).response([&](userinfo)
+			{
+				ASIO2_CHECK(client.io().running_in_this_thread());
+				ASIO2_CHECK(client.iopool().get(0).running_in_this_thread());
+				ASIO2_CHECK(asio2::get_last_error() == rpc::error::invalid_argument);
+				ext_data& ex = client.get_user_data<ext_data&>();
+				ex.async_call_counter++;
+			});
+
+			// this call will be failed, beacuse the param is incorrect.
+			client.async_call("del_user", u, std::string("lilei"), 1).response([&](userinfo)
+			{
+				ASIO2_CHECK(client.io().running_in_this_thread());
+				ASIO2_CHECK(client.iopool().get(0).running_in_this_thread());
+				ASIO2_CHECK(asio2::get_last_error() == rpc::error::invalid_argument);
+				ext_data& ex = client.get_user_data<ext_data&>();
+				ex.async_call_counter++;
+			});
+
+			// Chain calls : 
+			int sum = client.timeout(std::chrono::seconds(13)).call<int>("add", 11, 12);
+			ASIO2_CHECK(!asio2::get_last_error());
+			ASIO2_CHECK(sum == 11 + 12);
+
+			// Chain calls : 
+			sum = client.timeout(std::chrono::seconds(13)).call<int>("add", 11, 32);
+			ASIO2_CHECK(!asio2::get_last_error());
+			ASIO2_CHECK(sum == 11 + 32);
+
+			sum = client.timeout(std::chrono::seconds(13)).call<int>("add", 11);
+			ASIO2_CHECK(asio2::get_last_error() == rpc::error::invalid_argument);
+			ASIO2_CHECK(sum == 0);
+
+			sum = client.timeout(std::chrono::seconds(13)).call<int>("add", 11, 12, 13);
+			ASIO2_CHECK(asio2::get_last_error() == rpc::error::invalid_argument);
+			ASIO2_CHECK(sum == 0);
+
+			sum = client.timeout(std::chrono::seconds(13)).call<int>("add", "11", 12, 13);
+			ASIO2_CHECK(asio2::get_last_error() == rpc::error::invalid_argument);
+			ASIO2_CHECK(sum == 0);
+
+			// Chain calls : 
+			std::string str = client.call<std::string>("cat", "abc", "123");
+			ASIO2_CHECK(!asio2::get_last_error());
+			ASIO2_CHECK(str == "abc123");
+
+			client.async_call([&](int)
+			{
+				ASIO2_CHECK(client.io().running_in_this_thread());
+				ASIO2_CHECK(client.iopool().get(0).running_in_this_thread());
+				ASIO2_CHECK(asio2::get_last_error() == rpc::error::not_found);
+				ext_data& ex = client.get_user_data<ext_data&>();
+				ex.async_call_counter++;
+			}, "no_exists_fn", 10);
+
+			sum = client.timeout(std::chrono::seconds(13)).call<int>("no_exists_fn", 12, 13);
+			ASIO2_CHECK(asio2::get_last_error() == rpc::error::not_found);
+			ASIO2_CHECK(sum == 0);
+		}
+
+		while (server_connect_counter < test_client_count * 1)
+		{
+			ASIO2_TEST_WAIT_CHECK();
+		}
+
+		ASIO2_CHECK_VALUE(server_accept_counter    .load(), server_accept_counter     == test_client_count * 1);
+		ASIO2_CHECK_VALUE(server_connect_counter   .load(), server_connect_counter    == test_client_count * 1);
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			ASIO2_CHECK(!clients[i]->is_stopped());
+			ASIO2_CHECK( clients[i]->is_started());
+		}
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			ext_data& ex = clients[i]->get_user_data<ext_data&>();
+			while (ex.async_call_counter < 15)
+			{
+				ASIO2_TEST_WAIT_CHECK();
+			}
+		}
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			ext_data& ex = clients[i]->get_user_data<ext_data&>();
+			ASIO2_CHECK_VALUE(ex.async_call_counter, ex.async_call_counter == 15);
+		}
+
+		while (server_async_call_counter < test_client_count * 3)
+		{
+			ASIO2_TEST_WAIT_CHECK();
+		}
+
+		ASIO2_CHECK_VALUE(server_async_call_counter.load(), server_async_call_counter == test_client_count * 3);
+
+		for (int i = 0; i < test_client_count; i++)
+		{
+			clients[i]->stop();
+			ASIO2_CHECK( clients[i]->is_stopped());
+			ASIO2_CHECK(!clients[i]->is_started());
+			ASIO2_CHECK(!clients[i]->user_data_any().has_value());
+		}
+
+		// use this to ensure the ASIO2_CHECK(session_ptr->is_started());
+		while (server_disconnect_counter != test_client_count * 1)
+		{
+			ASIO2_TEST_WAIT_CHECK();
+		}
+
+		server.stop();
+		ASIO2_CHECK(server.is_stopped());
+
+		ASIO2_CHECK_VALUE(server_disconnect_counter.load(), server_disconnect_counter == test_client_count*1);
+		ASIO2_CHECK_VALUE(server_stop_counter      .load(), server_stop_counter       == 1);
+	}
+
+	ASIO2_TEST_END_LOOP;
+}
+
+
+ASIO2_TEST_SUITE
+(
+	"rpc_kcp",
+	ASIO2_TEST_CASE(rpc_test)
+)


### PR DESCRIPTION
As an upper layer protocol, RPC can be used with UDP based rdc, but kcp is more reliable and responsive, and can also use multicast groups to zone different connections, achieving the effect of native broadcast communication methods.

and the last pull request is #46 , thx for the review.

by the way.
i'm really like your design bout combine various template objects. how about expand the io_pool_t with the tech named  coroutine。
